### PR TITLE
投稿画面のエラーメッセージの修正

### DIFF
--- a/app/controllers/dishes_controller.rb
+++ b/app/controllers/dishes_controller.rb
@@ -34,7 +34,7 @@ class DishesController < ApplicationController
       # Log.create(dish_id: @dish.id, content: @dish.cook_memo)
       redirect_to dishes_path
     else
-      flash[:error_messages] = dish.errors.full_messages
+      # flash[:error_messages] = dish.errors.full_messages
       render :new
       # render 'dishes/new'
     end


### PR DESCRIPTION
#What
料理投稿画面料理名（必須項目）が入力されていない場合、投稿画面に戻る画面を作成

#Why
必須項目を入力しないと投稿出来ない画面を実装するため